### PR TITLE
Fix proxy

### DIFF
--- a/web2Way.c4i
+++ b/web2Way.c4i
@@ -15,7 +15,7 @@
     <combo>True</combo>
     <OnlineCategory>others</OnlineCategory>
     <proxies qty="1">
-		<proxy>webevents</proxy>
+		<proxy>web2Way</proxy>
     </proxies>
     <config>
         <power_management_method>AlwaysOn</power_management_method>


### PR DESCRIPTION
Proxy-less drivers need have the proxy element set to their filename (without the extension).